### PR TITLE
Fix typo in __osx spec

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -85,7 +85,7 @@ outputs:
         - libzlib
         - patch
         - curl
-        - __osx >={{ MACOS_DEPLOYMENT_TARGET|default("10.12") }}  # [osx]
+        - __osx >={{ MACOSX_DEPLOYMENT_TARGET|default("10.12") }}  # [osx and x86_64]
         - python_abi {{ python_maj_min }}.* *_graalpy{{ graalpy_maj_min.replace('.', '') }}_{{ python_maj_min.replace('.', '') }}_{{ graalpy_abi }}
       run_constrained:
         - python {{ gp_python_version }} {{ build_num }}_{{ graalpy_abi }}{{ graalpy_maj_min.replace('.', '') }}_graalpy


### PR DESCRIPTION
I randomly noticed that the variable here was `MACOS_DEPLOYMENT_TARGET` instead of `MACOSX_DEPLOYMENT_TARGET` set [here](https://github.com/conda-forge/graalpy-feedstock/blob/8c34a78e305dd86693cce6b0853b535e9cc893ea/recipe/conda_build_config.yaml#L17). I'm not bumping a build number because I think the default should handle it, so I think there's no change to the build.

Also, I'm pretty confused what's going on since I only see this being built for linux-64. But hey, I noticed this and thought I should point it out.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [X] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [X] Reset the build number to `0` (if the version changed)
* [X] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [X] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
